### PR TITLE
Add YouTube feed and embed player to Sermons page

### DIFF
--- a/website/src/app/components/YouTubeEmbed.tsx
+++ b/website/src/app/components/YouTubeEmbed.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+
+interface YouTubeEmbedProps {
+  videoId: string;
+  title: string;
+}
+
+export default function YouTubeEmbed({ videoId, title }: YouTubeEmbedProps) {
+  const [isLoaded, setIsLoaded] = useState(false);
+
+  return (
+    <div className="relative aspect-video">
+      {!isLoaded && (
+        <div className="absolute inset-0 bg-gray-200 rounded-lg flex items-center justify-center animate-pulse">
+          <svg className="w-16 h-16 text-gray-400" fill="currentColor" viewBox="0 0 24 24">
+            <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
+          </svg>
+        </div>
+      )}
+      <iframe
+        src={`https://www.youtube.com/embed/${videoId}`}
+        title={title}
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+        className="w-full h-full"
+        onLoad={() => setIsLoaded(true)}
+      />
+    </div>
+  );
+}

--- a/website/src/app/sermons/page.tsx
+++ b/website/src/app/sermons/page.tsx
@@ -1,32 +1,150 @@
 import type { Metadata } from "next";
 import Header from "../components/Header";
 import Footer from "../components/Footer";
+import YouTubeEmbed from "../components/YouTubeEmbed";
+
+const CHANNEL_ID = "UCOwgx7lSatXGdm2FVkNrcUg";
+const YOUTUBE_VIDEOS_URL = `https://www.youtube.com/channel/${CHANNEL_ID}/videos`;
+const RSS_URL = `https://www.youtube.com/feeds/videos.xml?channel_id=${CHANNEL_ID}`;
+
+type Video = {
+  id: string;
+  title: string;
+  publishedAt: string;
+};
 
 export const metadata: Metadata = {
   title: "Sermons | Prairie Lea Baptist Church",
-  description: "Watch and listen to recent sermons from Prairie Lea Baptist Church on Facebook.",
+  description: "Watch and listen to recent sermons from Prairie Lea Baptist Church on YouTube.",
 };
 
-export default function SermonsPage() {
+function decodeHtmlEntities(input: string) {
+  const entities: Record<string, string> = {
+    "&amp;": "&",
+    "&lt;": "<",
+    "&gt;": ">",
+    "&quot;": '"',
+    "&#39;": "'",
+    "&apos;": "'",
+  };
+
+  return input.replace(/&amp;|&lt;|&gt;|&quot;|&#39;|&apos;/g, (entity) => entities[entity] ?? entity);
+}
+
+
+async function getVideos(): Promise<Video[]> {
+  try {
+    const requestOptions = [
+      {
+        headers: {
+          "User-Agent":
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/127.0.0.0 Safari/537.36",
+          Accept: "application/atom+xml, application/xml, text/xml;q=0.9, */*;q=0.8",
+        },
+        next: { revalidate: 3600 },
+      },
+      {
+        next: { revalidate: 3600 },
+      },
+    ] as const;
+
+    let response: Response | null = null;
+
+    for (const options of requestOptions) {
+      const result = await fetch(RSS_URL, options);
+
+      if (result.ok) {
+        response = result;
+        break;
+      }
+    }
+
+    if (!response) {
+      throw new Error("Failed to fetch YouTube feed");
+    }
+
+    const xmlText = await response.text();
+    const entryRegex = /<entry>([\s\S]*?)<\/entry>/g;
+    const videos: Video[] = [];
+
+    for (const match of xmlText.matchAll(entryRegex)) {
+      const entry = match[1];
+      const idMatch = entry.match(/<yt:videoId>([\s\S]*?)<\/yt:videoId>/);
+      const titleMatch = entry.match(/<title>([\s\S]*?)<\/title>/);
+      const publishedMatch = entry.match(/<published>([\s\S]*?)<\/published>/);
+
+      if (!idMatch || !titleMatch || !publishedMatch) {
+        continue;
+      }
+
+      videos.push({
+        id: idMatch[1].trim(),
+        title: decodeHtmlEntities(titleMatch[1].trim()),
+        publishedAt: publishedMatch[1].trim(),
+      });
+
+      if (videos.length >= 4) {
+        break;
+      }
+    }
+
+    return videos
+      .sort((a, b) => new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime())
+      .slice(0, 4);
+  } catch {
+    return [];
+  }
+}
+
+export default async function SermonsPage() {
+  const videos = await getVideos();
+
   return (
     <div className="min-h-screen">
       <Header />
       <main className="bg-white">
-        <div className="max-w-6xl mx-auto px-4 py-16">
-          <h1 className="text-3xl lg:text-4xl font-bold text-gray-900 mb-6 font-[var(--font-arvo)]">
-            Sermons
-          </h1>
-          <p className="text-lg text-gray-700 mb-8 font-[var(--font-open-sans)]">
-            All of our recent sermons are available on Facebook—tap the button below to watch.
+        <div className="mx-auto max-w-6xl px-4 py-16">
+          <h1 className="mb-6 font-[var(--font-arvo)] text-3xl font-bold text-gray-900 lg:text-4xl">Sermons</h1>
+          <p className="mb-8 font-[var(--font-open-sans)] text-lg text-gray-700">
+            Watch our latest sermons from YouTube. New videos are refreshed every hour.
           </p>
-          <a
-            href="https://www.facebook.com/share/1B1h3bQMQ5/?mibextid=wwXIfr"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center bg-[#2563eb] hover:bg-[#1d4ed8] text-white px-6 py-3 rounded-lg font-medium transition-colors text-lg"
-          >
-            Visit Our Sermons on Facebook
-          </a>
+
+          {videos.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+              {videos.map((video) => (
+                <div
+                  key={video.id}
+                  className="bg-white rounded-lg shadow-md overflow-hidden hover:shadow-lg transition-shadow"
+                >
+                  <YouTubeEmbed videoId={video.id} title={video.title} />
+                  <div className="p-4">
+                    <h3 className="font-semibold text-gray-900 mb-2 font-[var(--font-arvo)]">{video.title}</h3>
+                    <p className="text-sm text-gray-600 font-[var(--font-open-sans)]">
+                      {new Date(video.publishedAt).toLocaleDateString("en-US", {
+                        year: "numeric",
+                        month: "long",
+                        day: "numeric",
+                      })}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-6">
+              <p className="mb-4 font-[var(--font-open-sans)] text-lg text-gray-700">
+                We couldn&apos;t load recent sermon videos right now.
+              </p>
+              <a
+                href={YOUTUBE_VIDEOS_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center justify-center rounded-lg bg-[#2563eb] px-6 py-3 text-lg font-medium text-white transition-colors hover:bg-[#1d4ed8]"
+              >
+                View Sermons on YouTube
+              </a>
+            </div>
+          )}
         </div>
       </main>
       <Footer />


### PR DESCRIPTION
### Motivation
- Replace the previous Facebook-centric sermons experience with direct YouTube embeds so visitors can watch recent sermons on the site. 
- Provide a resilient, server-side fetch of the channel RSS feed and parse recent videos for display. 
- Improve user experience with an embedded player and a loading skeleton plus a fallback link to the YouTube channel.

### Description
- Added a new client component `YouTubeEmbed` that renders an iframe for a given `videoId` with a loading skeleton and sets `isLoaded` on `onLoad`.
- Updated the sermons page to use YouTube: added `CHANNEL_ID`, `RSS_URL`, and a server-side `getVideos` function that fetches and parses the YouTube RSS feed, decodes HTML entities with `decodeHtmlEntities`, and returns up to 4 recent videos.
- Replaced the Facebook CTA and static copy with a dynamic grid that maps videos to cards showing the `YouTubeEmbed`, title, and formatted publish date, and a fallback block that links to the channel at `YOUTUBE_VIDEOS_URL` when fetch fails.
- Adjusted page metadata `description` to reference YouTube and applied styling changes to layout and typography.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a90dab64b4832da6a9047e876a6e90)